### PR TITLE
Add guides to meet most of GitHub Community Standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) SRG SSR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following guides are offered to help you improve your repository:
 
 ## Contributing
 
-We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to [open issues](https://github.com/SRGSSR/guilde-plateformes-propres/issues/new), [submit pull requests](https://github.com/SRGSSR/guilde-plateformes-propres/compare), or share your ideas.
+We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to [open issues](https://github.com/SRGSSR/guilde-plateformes-propres/issues/new), [submit pull requests](https://github.com/SRGSSR/guilde-plateformes-propres/compare), or [share your ideas](https://github.com/SRGSSR/guilde-plateformes-propres/discussions).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following guides are offered to help you improve your repository:
 
 ## Contributing
 
-We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to open issues, submit pull requests, or share your ideas.
+We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to [open issues](https://github.com/SRGSSR/guilde-plateformes-propres/issues/new), [submit pull requests](https://github.com/SRGSSR/guilde-plateformes-propres/compare), or share your ideas.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following guides are offered to help you improve your repository:
 - [Readme Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
 - [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project.
 - [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure everyone can safely contribute.
-- [License Guide](docs/guides/LICENSE_GUDE.md): Pick an appropriate license.
+- [License Guide](docs/guides/LICENSE_GUIDE.md): Pick an appropriate license.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# guilde-plateformes-propres
-Guides et modèles pour standardiser la qualité des projets
+# RTS Development Guidelines
+
+A guide for promoting best practices among RTS code repositories.
+
+## Introduction
+
+The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership and make it easier for newcomers to start, or for more seasoned developers to contribute to any project.
+
+## Guides
+
+The following guides are offered to help you improve your repository
+
+- [README Guide](docs/guides/README_GUIDE.md): Write a great readme for your repository.
+- [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project by providing a clear guide on how others can contribute.
+- [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide a code of conduct to ensure everyone can safely contribute.
+
+## Contributing
+
+We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to open issues, submit pull requests, or share your ideas.
+
+## License
+
+See the [LICENSE](LICENSE) file for more information.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following guides are offered to help you improve your repository:
 - [README Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
 - [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project by providing a clear guide on how others can contribute.
 - [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide a code of conduct to ensure everyone can safely contribute.
+- [License Guide](docs/guides/LICENSE_GUDE.md): Pick an appropriate license.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ A guide for promoting best practices among RTS code repositories.
 
 ## Introduction
 
-The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership, make it easier for newcomers to start and for more seasoned developers to contribute to any project.
+The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership, make it easier for newcomers to start and for seasoned developers to contribute to any project.
 
 ## Guides
 
 The following guides are offered to help you improve your repository:
 
-- [README Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
-- [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project by providing a clear guide on how others can contribute.
-- [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide a code of conduct to ensure everyone can safely contribute.
+- [Readme Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
+- [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project.
+- [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure everyone can safely contribute.
 - [License Guide](docs/guides/LICENSE_GUDE.md): Pick an appropriate license.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The following guides are offered to help you improve your repository:
 - [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure everyone can safely contribute.
 - [License Guide](docs/guides/LICENSE_GUIDE.md): Pick an appropriate license.
 
+> [!TIP]
+> GitHub [Community Standards](https://opensource.guide/) are a great source of information and best practices. You can check that your project follows these standards at any time by checking _Community Standards_ under the _Insights_ section.
+
 ## Contributing
 
 We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to open issues, submit pull requests, or share your ideas.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A guide for promoting best practices among RTS code repositories.
 
 ## Introduction
 
-The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership and make it easier for newcomers to start, or for more seasoned developers to contribute to any project.
+The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership, make it easier for newcomers to start and for more seasoned developers to contribute to any project.
 
 ## Guides
 
-The following guides are offered to help you improve your repository
+The following guides are offered to help you improve your repository:
 
-- [README Guide](docs/guides/README_GUIDE.md): Write a great readme for your repository.
+- [README Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
 - [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project by providing a clear guide on how others can contribute.
 - [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide a code of conduct to ensure everyone can safely contribute.
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thank you very much for your interest in contributing to our project! As a public service company, we want to shape a product that better matches our user needs and desires. Ideas or direct contributions are therefore warmly welcome and will be considered with great care, provided they fulfill a few requirements listed in this document. Please read it first before you decide to contribute.
+
+## Purpose
+
+Please follow the present contributing guidelines so that we can efficiently consider your proposal. You should also read or our [code of conduct](CODE_OF_CONDUCT.md), providing a few guidelines to keep interactions as respectful as possible.
+
+## Contributions we are looking for
+
+Any kind of contribution is welcome, as long as it improves the overall quality of this documentation, for example:
+
+* Requests for new topics or ideas.
+* General documentation improvements.
+
+Contributions can either take the form of simple issues where you describe what needs to be addressed. You can also directly open pull requests to submit ideas or fixes.
+
+## Making a contribution
+
+You can use issues to discuss your ideas or propose new topics. People with a programming background can also submit changes directly via pull requests. Creating issues or pull requests requires you to own or [open](https://github.com/join) a GitHub account.
+
+If you are not sure about the likelihood of a change you propose to be accepted, please open an issue first. This way you can avoid creating an entire pull request we will never be able to merge.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you very much for your interest in contributing to our project! As a publi
 
 ## Purpose
 
-Please follow the present contributing guidelines so that we can efficiently consider your proposal. You should also read or our [code of conduct](CODE_OF_CONDUCT.md), providing a few guidelines to keep interactions as respectful as possible.
+Please follow the present contributing guidelines so that we can efficiently consider your proposal. You should also read our [code of conduct](CODE_OF_CONDUCT.md), providing a few guidelines to keep interactions as respectful as possible.
 
 ## Contributions we are looking for
 

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -4,7 +4,7 @@ Promote a welcoming and safe environment for discussions and contributions.
 
 ## Picking a Code of Conduct
 
-The [Contributor Covenant](https://www.contributor-covenant.org/) provides a great Code of Conduct. Except if you want to write your own you should simply adopt it.
+The [Contributor Covenant](https://www.contributor-covenant.org/) provides a great Code of Conduct. You can use it as-is, adapt it to your needs, or write your own document.
 
 ## Adding a Code of Conduct
 

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -1,0 +1,3 @@
+# Code of Conduct Guide
+
+TBD

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -8,4 +8,4 @@ The [Contributor Covenant](https://www.contributor-covenant.org/) provides a gre
 
 ## Adding a Code of Conduct
 
-Add a file called `CODE_OF_CONDUCT.md` to your repository with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `CODE_OF_CONDUCT.md` to the root of your repository, the `docs` folder, or the `.github` folder, with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -2,6 +2,9 @@
 
 Promote a welcoming and safe environment for discussions and contributions.
 
+> [!TIP]
+> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).
+
 ## Picking a Code of Conduct
 
 The [Contributor Covenant](https://www.contributor-covenant.org/) provides a great Code of Conduct. You can use it as-is, adapt it to your needs, or write your own document.

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -1,3 +1,11 @@
 # Code of Conduct Guide
 
-TBD
+To promote a welcoming and safe environment for discussions and contributions your repository should include a code of conduct.
+
+## Picking a Code of Conduct
+
+The [Contributor Covenant](https://www.contributor-covenant.org/) provides a sound code of conduct.
+
+## Adding a Code of Conduct
+
+Add a file called `CODE_OF_CONDUCT.md` to the repository with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -1,11 +1,11 @@
 # Code of Conduct Guide
 
-To promote a welcoming and safe environment for discussions and contributions your repository should include a code of conduct.
+Promote a welcoming and safe environment for discussions and contributions.
 
 ## Picking a Code of Conduct
 
-The [Contributor Covenant](https://www.contributor-covenant.org/) provides a sound code of conduct.
+The [Contributor Covenant](https://www.contributor-covenant.org/) provides a great Code of Conduct. Except if you want to write your own you should simply adopt it.
 
 ## Adding a Code of Conduct
 
-Add a file called `CODE_OF_CONDUCT.md` to the repository with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `CODE_OF_CONDUCT.md` to your repository with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+TBD

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -11,4 +11,4 @@ Writing Contributing guidelines depends on your project and how your team decide
 
 ## Adding Contributing guidelines
 
-Add a file called `CONTRIBUTING.md` to your repository with the text you wrote. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `CONTRIBUTING.md` to the root of your repository, the `docs` folder, or the `.github` folder, with the text you wrote. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -2,6 +2,10 @@
 
 Provide more context about contributions you are looking for and how they should occur.
 
+> [!TIP]
+> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors).
+
+
 ## Writing Contributing guidelines
 
 Writing Contributing guidelines depends on your project and how your team decides to process contributions. To help you:

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -1,3 +1,14 @@
 # Contributing Guide
 
-TBD
+Provide more context about contributions you are looking for and how they should occur.
+
+## Writing Contributing guidelines
+
+Writing Contributing guidelines depends on your project and how your team decides to process contributions. To help you:
+
+- The [Pillarbox Contributing guidelines](https://github.com/SRGSSR/pillarbox-apple/blob/main/docs/CONTRIBUTING.md) is an example describing which contributions are considered, how they should occur (with links to the corresponding templates) and how they will be processed.
+- The following [template](https://github.com/nayafia/contributing-template) can be used if you need to write Contributing guidelines tailored to your needs.
+
+## Adding Contributing guidelines
+
+Add a file called `CONTRIBUTING.md` to your repository with the text you wrote. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -8,7 +8,7 @@ The following [online guide](https://choosealicense.com/) is an excellent way to
 
 ## Adding a license
 
-Add a file called `LICENSE` to your repository with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `LICENSE` to the root of your repository, the `docs` folder, or the `.github` folder, with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
 
 You can either repeat the license in each file requiring it but this is generally cumbersome. To make your life easier you can use the following reduced license instead, which points to the main license file for more information:
 

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -1,6 +1,6 @@
 # License Guide
 
-Providing license information in your code repository is essential ensure the conditions applicable to your project are transparent.
+Make applicable license conditions transparent.
 
 ## Choosing a license
 
@@ -8,7 +8,7 @@ The following [online guide](https://choosealicense.com/) is an excellent way to
 
 ## Adding a license
 
-Add a file called `LICENSE` to the repository with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `LICENSE` to your repository with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
 
 You can either repeat the license in each file requiring it but this is generally cumbersome. To make your life easier you can use the following reduced license instead, which points to the main license file for more information:
 
@@ -19,3 +19,5 @@ You can either repeat the license in each file requiring it but this is generall
 //  License information is available from the LICENSE file.
 //
 ```
+
+Avoid dates in license information since they have no real values and are likely never correctly updated.

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -6,9 +6,9 @@ Providing license information in your code repository is essential ensure the co
 
 The following [online guide](https://choosealicense.com/) is an excellent way to pick a license.
 
-## Providing a license
+## Adding a license
 
-Your license file should be called `LICENSE` and be put at the root of your repository.
+Add a file called `LICENSE` to the repository with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
 
 You can either repeat the license in each file requiring it but this is generally cumbersome. To make your life easier you can use the following reduced license instead, which points to the main license file for more information:
 

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -1,0 +1,21 @@
+# License Guide
+
+Providing license information in your code repository is essential ensure the conditions applicable to your project are transparent.
+
+## Choosing a license
+
+The following [online guide](https://choosealicense.com/) is an excellent way to pick a license.
+
+## Providing a license
+
+Your license file should be called `LICENSE` and be put at the root of your repository.
+
+You can either repeat the license in each file requiring it but this is generally cumbersome. To make your life easier you can use the following reduced license instead, which points to the main license file for more information:
+
+```
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+```

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -2,6 +2,9 @@
 
 Make applicable license conditions transparent.
 
+> [!TIP]
+> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository).
+
 ## Choosing a license
 
 The following [online guide](https://choosealicense.com/) is an excellent way to pick a license.

--- a/docs/guides/README_GUIDE.md
+++ b/docs/guides/README_GUIDE.md
@@ -1,0 +1,3 @@
+# README Guide
+
+TBD

--- a/docs/guides/README_GUIDE.md
+++ b/docs/guides/README_GUIDE.md
@@ -1,3 +1,3 @@
-# README Guide
+# Readme Guide
 
 TBD


### PR DESCRIPTION
# Description

This PR adds documentation to promote adoption of GitHub Community Standards in RTS projects.

# Changes made

- Write main readme.
- Add guides for:
  - License.
  - Code of Conduct.
  - Contributing.
- Add empty file for a soon-to-come Readme guide.
- Add License, Code of Conduct and Contributing files for the repository.
- Add `.editorconfig` for more consistent formatting.
- Configure the repository to force contributions through PRs with at least 1 successful review.