### PR TITLE
chore: add a readme guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+### Intellij ###
+.idea
+
+### VisualStudioCode ###
+.vscode

--- a/README.md
+++ b/README.md
@@ -4,26 +4,41 @@ A guide for promoting best practices among RTS code repositories.
 
 ## Introduction
 
-The software industry is constantly evolving. Our own practices should similarly evolve to disseminate knowledge throughout teams, share ownership, make it easier for newcomers to start and for seasoned developers to contribute to any project.
+The software industry is constantly evolving. Our own practices should similarly evolve to
+disseminate knowledge throughout teams, share ownership, make it easier for newcomers to start and
+for seasoned developers to contribute to any project.
 
 ## Guides
 
 The following guides are offered to help you improve your repository:
 
 - [Readme Guide](docs/guides/README_GUIDE.md): Write a great introductory text for your repository.
-- [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and contribution to your project.
-- [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure everyone can safely contribute.
+- [Contributing Guide](docs/guides/CONTRIBUTING_GUIDE.md): Ensure smooth collaboration and
+  contribution to your project.
+- [Code of Conduct Guide](docs/guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure
+  everyone can safely contribute.
 - [License Guide](docs/guides/LICENSE_GUIDE.md): Pick an appropriate license.
 
 > [!TIP]
-> GitHub Community Standards are a great source of information and best practices. You can check that your project follows these standards at any time by checking _Community Standards_ under the _Insights_ section.
+> GitHub Community Standards are a great source of information and best practices. You can check
+> that your project follows these standards at any time by checking _Community Standards_ under the
+_Insights_ section.
 
-More sources are available online for further reading; you can start exploring them at [opensource.guide](https://opensource.guide/).
+More sources are available online for further reading; you can start exploring them
+at [opensource.guide](https://opensource.guide/).
 
 ## Contributing
 
-We welcome contributions from everyone. To get started, please read our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free to [open issues](https://github.com/SRGSSR/guilde-plateformes-propres/issues/new), [submit pull requests](https://github.com/SRGSSR/guilde-plateformes-propres/compare), or [share your ideas](https://github.com/SRGSSR/guilde-plateformes-propres/discussions).
+We welcome contributions from everyone. To get started, please read
+our [Contribution Guidelines](docs/CONTRIBUTING.md). Feel free
+to [open issues][open-issues], [submit pull requests][submit-pr], or [share your ideas][dicussions].
 
 ## License
 
 See the [LICENSE](LICENSE) file for more information.
+
+[open-issues]: https://github.com/SRGSSR/guilde-plateformes-propres/issues/new
+
+[submit-pr]: https://github.com/SRGSSR/guilde-plateformes-propres/compare
+
+[discussions]: https://github.com/SRGSSR/guilde-plateformes-propres/discussions

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,22 +1,33 @@
 # Contributing
 
-Thank you very much for your interest in contributing to our project! As a public service company, we want to shape a product that better matches our user needs and desires. Ideas or direct contributions are therefore warmly welcome and will be considered with great care, provided they fulfill a few requirements listed in this document. Please read it first before you decide to contribute.
+Thank you very much for your interest in contributing to our project! As a public service company,
+we want to shape a product that better matches our user needs and desires. Ideas or direct
+contributions are therefore warmly welcome and will be considered with great care, provided they
+fulfill a few requirements listed in this document. Please read it first before you decide to
+contribute.
 
 ## Purpose
 
-Please follow the present contributing guidelines so that we can efficiently consider your proposal. You should also read our [code of conduct](CODE_OF_CONDUCT.md), providing a few guidelines to keep interactions as respectful as possible.
+Please follow the present contributing guidelines so that we can efficiently consider your proposal.
+You should also read our [code of conduct](CODE_OF_CONDUCT.md), providing a few guidelines to keep
+interactions as respectful as possible.
 
 ## Contributions we are looking for
 
-Any kind of contribution is welcome, as long as it improves the overall quality of this documentation, for example:
+Any kind of contribution is welcome, as long as it improves the overall quality of this
+documentation, for example:
 
 * Requests for new topics or ideas.
 * General documentation improvements.
 
-Contributions can either take the form of simple issues where you describe what needs to be addressed. You can also directly open pull requests to submit ideas or fixes.
+Contributions can either take the form of simple issues where you describe what needs to be
+addressed. You can also directly open pull requests to submit ideas or fixes.
 
 ## Making a contribution
 
-You can use issues to discuss your ideas or propose new topics. People with a programming background can also submit changes directly via pull requests. Creating issues or pull requests requires you to own or [open](https://github.com/join) a GitHub account.
+You can use issues to discuss your ideas or propose new topics. People with a programming background
+can also submit changes directly via pull requests. Creating issues or pull requests requires you to
+own or [open](https://github.com/join) a GitHub account.
 
-If you are not sure about the likelihood of a change you propose to be accepted, please open an issue first. This way you can avoid creating an entire pull request we will never be able to merge.
+If you are not sure about the likelihood of a change you propose to be accepted, please open an
+issue first. This way you can avoid creating an entire pull request we will never be able to merge.

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -3,12 +3,21 @@
 Promote a welcoming and safe environment for discussions and contributions.
 
 > [!TIP]
-> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).
+> More information is available
+>
+from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).
 
 ## Picking a Code of Conduct
 
-The [Contributor Covenant](https://www.contributor-covenant.org/) provides a great Code of Conduct. You can use it as-is, adapt it to your needs, or write your own document.
+The [Contributor Covenant][contribution-covenant] provides a great Code of Conduct. You can use it
+as-is, adapt it to your needs, or write your own document.
 
 ## Adding a Code of Conduct
 
-Add a file called `CODE_OF_CONDUCT.md` to the root of your repository, the `docs` folder, or the `.github` folder, with the text of the Code of Conduct you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `CODE_OF_CONDUCT.md` to the root of your repository, the `docs` folder, or
+the `.github` folder, with the text of the Code of Conduct you chose. GitHub automatically adds a
+link to this file in the _About_ section of your repository homepage.
+
+[github-documentation]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
+
+[contribution-covenant]: https://www.contributor-covenant.org/

--- a/docs/guides/CODE_OF_CONDUCT_GUIDE.md
+++ b/docs/guides/CODE_OF_CONDUCT_GUIDE.md
@@ -3,13 +3,11 @@
 Promote a welcoming and safe environment for discussions and contributions.
 
 > [!TIP]
-> More information is available
->
-from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).
+> More information is available from [GitHub documentation][github-documentation].
 
 ## Picking a Code of Conduct
 
-The [Contributor Covenant][contribution-covenant] provides a great Code of Conduct. You can use it
+The [Contributor Covenant][contributor-covenant] provides a great Code of Conduct. You can use it
 as-is, adapt it to your needs, or write your own document.
 
 ## Adding a Code of Conduct
@@ -19,5 +17,4 @@ the `.github` folder, with the text of the Code of Conduct you chose. GitHub aut
 link to this file in the _About_ section of your repository homepage.
 
 [github-documentation]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
-
-[contribution-covenant]: https://www.contributor-covenant.org/
+[contributor-covenant]: https://www.contributor-covenant.org/

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -23,7 +23,5 @@ the `.github` folder, with the text you wrote. GitHub automatically adds a link 
 _About_ section of your repository homepage.
 
 [github-documentation]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors
-
 [pillarbox-contributing]: https://github.com/SRGSSR/pillarbox-apple/blob/main/docs/CONTRIBUTING.md
-
 [contributing-template]: https://github.com/nayafia/contributing-template

--- a/docs/guides/CONTRIBUTING_GUIDE.md
+++ b/docs/guides/CONTRIBUTING_GUIDE.md
@@ -3,16 +3,27 @@
 Provide more context about contributions you are looking for and how they should occur.
 
 > [!TIP]
-> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors).
-
+> More information is available from [GitHub documentation][github-documentation].
 
 ## Writing Contributing guidelines
 
-Writing Contributing guidelines depends on your project and how your team decides to process contributions. To help you:
+Writing Contributing guidelines depends on your project and how your team decides to process
+contributions. To help you:
 
-- The [Pillarbox Contributing guidelines](https://github.com/SRGSSR/pillarbox-apple/blob/main/docs/CONTRIBUTING.md) is an example describing which contributions are considered, how they should occur (with links to the corresponding templates) and how they will be processed.
-- The following [template](https://github.com/nayafia/contributing-template) can be used if you need to write Contributing guidelines tailored to your needs.
+- The [Pillarbox Contributing guidelines][pillarbox-contributing] is an example describing which
+  contributions are considered, how they should occur (with links to the corresponding templates)
+  and how they will be processed.
+- The following [template][contributing-template] can be used if you need to write Contributing
+  guidelines tailored to your needs.
 
 ## Adding Contributing guidelines
 
-Add a file called `CONTRIBUTING.md` to the root of your repository, the `docs` folder, or the `.github` folder, with the text you wrote. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `CONTRIBUTING.md` to the root of your repository, the `docs` folder, or
+the `.github` folder, with the text you wrote. GitHub automatically adds a link to this file in the
+_About_ section of your repository homepage.
+
+[github-documentation]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors
+
+[pillarbox-contributing]: https://github.com/SRGSSR/pillarbox-apple/blob/main/docs/CONTRIBUTING.md
+
+[contributing-template]: https://github.com/nayafia/contributing-template

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -30,4 +30,4 @@ license file for more information:
 Avoid dates in license information since they have no real values and are likely never correctly
 updated.
 
-[github-documentatiojn]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository
+[github-documentation]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository

--- a/docs/guides/LICENSE_GUIDE.md
+++ b/docs/guides/LICENSE_GUIDE.md
@@ -3,7 +3,7 @@
 Make applicable license conditions transparent.
 
 > [!TIP]
-> More information is available from [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository).
+> More information is available from [GitHub documentation][github-documentation].
 
 ## Choosing a license
 
@@ -11,9 +11,13 @@ The following [online guide](https://choosealicense.com/) is an excellent way to
 
 ## Adding a license
 
-Add a file called `LICENSE` to the root of your repository, the `docs` folder, or the `.github` folder, with the text of the license you chose. GitHub automatically adds a link to this file in the _About_ section of your repository homepage.
+Add a file called `LICENSE` to the root of your repository, the `docs` folder, or the `.github`
+folder, with the text of the license you chose. GitHub automatically adds a link to this file in the
+_About_ section of your repository homepage.
 
-You can either repeat the license in each file requiring it but this is generally cumbersome. To make your life easier you can use the following reduced license instead, which points to the main license file for more information:
+You can either repeat the license in each file requiring it but this is generally cumbersome. To
+make your life easier you can use the following reduced license instead, which points to the main
+license file for more information:
 
 ```
 //
@@ -23,4 +27,7 @@ You can either repeat the license in each file requiring it but this is generall
 //
 ```
 
-Avoid dates in license information since they have no real values and are likely never correctly updated.
+Avoid dates in license information since they have no real values and are likely never correctly
+updated.
+
+[github-documentatiojn]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository

--- a/docs/guides/README_GUIDE.md
+++ b/docs/guides/README_GUIDE.md
@@ -1,3 +1,68 @@
-# Readme Guide
+# `<Project Name>`
 
-TBD
+Introduce your project with a clear overview of its goals, providing essential context and
+addressing fundamental questions.
+
+> [!Tip]
+> Enhance your project's visual appeal with a representative image and badges.
+> Explore [Adding workflow badges][workflow-badges] for guidance. If your project is an application,
+> include production version links (e.g., app store links) and incorporate screenshots to showcase
+> its appearance.
+
+> [!Warning]
+> Avoid adding a table of contents unless it serves a specific purpose, as GitHub generates one
+> automatically.
+
+## Quick Guide
+
+**Prerequisites and Requirements**
+
+List any prerequisites or requirements needed before setting up the project.
+
+**Setup for Libraries, Components, or Frameworks**
+
+For libraries, components, or frameworks, explain a typical setup, including installation from a
+package distribution manager and a simple use case.
+
+> [!Tip]
+> Avoid detailed development environment setup in this section.
+
+**Running an Application Locally**
+
+Provide instructions on running the application locally for application projects.
+
+## Documentation
+
+Include links to additional documentation resources related to your project in this section.
+
+## Contributing
+
+Clarify how others can contribute to the project, with guidelines for bug reports, feature requests,
+or code contributions. Add a link to the Contribution guidelines (refer
+to [Contribution Guide](./CODE_OF_CONDUCT_GUIDE.md)).
+
+**Automated Processes**
+
+Describe any automated processes that facilitate smoother collaboration. For instance, explain how
+to run linting tools. No need to justify conventions; simply enumerate them.
+
+> [!Tip]
+> For libraries, components, or frameworks, explain how to set up a local environment for
+> development. Avoid detailing this in the 'Quick Guide' section.
+
+## License
+
+Provide a link to the License (refer to [License Guide](LICENSE_GUIDE.md)).
+
+## Acknowledgements
+
+Give credit to third-party libraries, tools, or individuals whose work is used or inspired your
+project.
+
+---
+
+> [!Note]
+> Customize this template according to the specific needs of your projects. Add or remove sections
+> based on the nature of each project.
+
+[workflow-badges]: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge


### PR DESCRIPTION
## Description

Resolves #1 by adding a readme guide detailing the following sections: `Quick Guide`, `Documentation`, `Contributing`, `License` and `Acknowledgements`.

## Changes made

- Adds a limit of 100 characters per line for the markdown files.
- Adds a `.gitignore` file.