### PR TITLE
ci: add pull request previews

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,0 +1,22 @@
+name: Github Page
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  github-page:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy GitHub Page 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+          branch: gh-pages
+          folder: public
+          force: false
+          clean-exclude: pr-preview/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,25 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy Preview 🚀
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: public
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview


### PR DESCRIPTION
## Description

Introduces pull request previews using `rossjrw/pr-preview-action`. This new workflow enables us to review both visual and functional changes before merging.

The preview functionality work in the following manner:

1. **Triggering a Preview**: Whenever a pull request is either opened, re-opened, or updated, the contents of the `public` directory are copied under `pr-preview/pr-${github.ref}` located in the `gh-pages` branch.

2. **Cleaning Up**: Once a pull request is closed, the corresponding preview folder (specific to the closed pull request) is deleted.