### PR TITLE
Create `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @defagos @fredhdroz @jboix @MGaetan89 @oiledCode @SamuelBeaurepaire


### PR DESCRIPTION
This PR creates the `CODEOWNERS` file in the project. This automatically assign the PR to the right person for review.
Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners