### PR TITLE
Add Security guidelines

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -18,6 +18,8 @@ The following guides are offered to help you improve your repository:
 - [Code of Conduct Guide](./guides/CODE_OF_CONDUCT_GUIDE.md): Provide guidelines to ensure
   everyone can safely contribute.
 - [License Guide](./guides/LICENSE_GUIDE.md): Pick an appropriate license.
+- [Security Guide](./guides/SECURITY_GUIDE.md): Provide guidelines for optimizing the security of
+  the repository and its content.
 
 > [!TIP]
 > GitHub Community Standards are a great source of information and best practices. You can check

--- a/public/_sidebar.md
+++ b/public/_sidebar.md
@@ -9,3 +9,4 @@
 * [Contributor's Handbook](/guides/CONTRIBUTING_GUIDE.md)
 * [Pull Request Manual](/guides/PULL_REQUEST_GUIDE.md)
 * [Code of Conduct Guidelines](/guides/CODE_OF_CONDUCT_GUIDE.md)
+* [Security policy Guidelines](/guides/SECURITY_GUIDE.md)

--- a/public/guides/SECURITY_GUIDE.md
+++ b/public/guides/SECURITY_GUIDE.md
@@ -1,0 +1,82 @@
+# GitHub Security Guide
+
+## Repository Access Settings
+For products with sensitive information or proprietary code, set the repository as private to
+maintain confidentiality and control access. For open-source projects or non-sensitive content,
+consider making the repository public to encourage collaboration and transparency.
+
+## Enable Dependency Graph for Private Repositories
+Enable the Dependency Graph feature for private repositories to automatically track and manage
+dependencies.
+This feature helps identify and address vulnerabilities in project dependencies by providing
+insights into package versions and usage.
+
+## Enable Dependabot Alerts, Security Updates, and Version Updates
+Enable Dependabot alerts to receive notifications about vulnerable dependencies in your
+repositories.
+Configure Dependabot to automatically apply security updates and version updates when available.
+Regularly review and merge Dependabot pull requests to keep dependencies up-to-date and secure.
+
+## Code Scanning
+You may enable GitHub code scanning to automatically detect and flag potential security
+vulnerabilities in your code.
+You can also integrate code scanning into your CI/CD pipeline to catch issues early in the
+development process.
+Address identified vulnerabilities promptly and thoroughly to minimize security risks.
+
+## Secret Scanning
+You may enable secret scanning to detect and prevent the exposure of sensitive information, such as
+API keys, passwords, and tokens, in your repositories.
+Regularly review secret scanning alerts and take action to remove or secure any exposed secrets.
+
+---
+
+*You can find more information about these security features in the official [GitHub documentation][github-doc].*
+
+## Write a security policy
+Having a security policy ensures easy access to maintained versions list, major security rules and
+vulnerabilities report guidelines among other things.
+
+This template will assist you in creating a concise SECURITY POLICY for your project which should
+be a `SECURITY.md` file at the root of the repository.
+
+```markdown
+# Security Policy
+
+## Supported versions
+> Use this section to tell people about which versions of your project are currently being
+> supported with security updates.
+
+Sample table:
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Dependencies
+Only supported versions of software, libraries, and frameworks shall be used. Regularly update
+dependencies to ensure compliance with supported versions and address known vulnerabilities.
+
+## Secrets
+Under no circumstances shall sensitive information, such as passwords, API keys, or access tokens,
+be stored in the repository. Securely manage secrets using a dedicated secrets management tool
+or environment variables.
+
+## Reporting a Vulnerability
+To report a vulnerability, open an issue with the "security" label on GitHub. Additionally, open a
+Jira SMAC issue with a link to the GitHub issue for tracking and coordination.
+
+## Code Reviews
+All code changes must undergo thorough review by at least one other team member before being merged
+into the main branch. Code reviewers shall ensure that changes meet coding standards, security
+requirements, and best practices.
+
+## Compliance
+This repository shall comply with relevant laws, regulations, and industry standards governing the
+protection of data and intellectual property. Regular audits and assessments shall be conducted to
+verify compliance and address any non-compliance issues promptly.
+```
+
+[github-doc]: https://docs.github.com/en/code-security/getting-started/securing-your-repository


### PR DESCRIPTION
## Description

This PR add security related guidelines to address issue #3 

## Changes Made

- Add guide for security repo setup and security policy template
- Add links to the main readme and docsify's sidebar

## Checklist:

- [x] I have followed the style guidelines of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have reviewed the [CONTRIBUTING.md](../docs/CONTRIBUTING.md) guidelines.
